### PR TITLE
feat(proxy): enhance fault rule management and add new API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,8 @@ mvn test -pl rodriguez-core -Dtest=HarnessServerTest
 # Run the harness locally
 mvn exec:java -pl rodriguez-build
 
-# Build Docker image
-mvn jib:dockerBuild -pl rodriguez-build
+# Build Docker image (install first to update ~/.m2 for Jib)
+mvn install -DskipTests && mvn jib:dockerBuild -pl rodriguez-build
 
 # Build GraalVM native image (requires GraalVM 21 JDK)
 mvn -Pgraalvm package
@@ -117,7 +117,7 @@ git checkout master && git merge develop
 git tag v0.4.0
 
 # 4. Build and push Docker image
-mvn jib:dockerBuild -pl rodriguez-build
+mvn install -DskipTests && mvn jib:dockerBuild -pl rodriguez-build
 # → kawasima/rodriguez:latest + kawasima/rodriguez:0.4.0
 
 # 5. Push

--- a/examples/nodejs/compose.yml
+++ b/examples/nodejs/compose.yml
@@ -1,0 +1,19 @@
+services:
+  upstream:
+    image: node:22-slim
+    working_dir: /app
+    init: true
+    volumes:
+      - ./src:/app/src:ro
+      - ./package.json:/app/package.json:ro
+    command: ["node", "src/upstream-server.js", "8080"]
+
+  rodriguez:
+    image: kawasima/rodriguez
+    ports:
+      - "10200-10220:10200-10220"
+    volumes:
+      - ./rodriguez-proxy.json:/config/rodriguez.json:ro
+    command: ["-c", "/config/rodriguez.json"]
+    depends_on:
+      - upstream

--- a/examples/nodejs/rodriguez-proxy.json
+++ b/examples/nodejs/rodriguez-proxy.json
@@ -1,0 +1,16 @@
+{
+  "controlPort": 10200,
+  "ports": {
+    "10201": { "type": "RefuseConnection" },
+    "10205": { "type": "SlowResponse" },
+    "10208": { "type": "BrokenJson" },
+    "10212": { "type": "RefuseAuthentication" }
+  },
+  "extensions": {
+    "proxy": {
+      "port": 10220,
+      "upstream": "http://upstream:8080",
+      "paths": ["/products/.*"]
+    }
+  }
+}

--- a/examples/nodejs/src/circuit-breaker.js
+++ b/examples/nodejs/src/circuit-breaker.js
@@ -1,0 +1,63 @@
+/**
+ * Minimal circuit breaker for demonstration purposes.
+ *
+ * States:
+ *   CLOSED   — requests pass through normally
+ *   OPEN     — requests are immediately rejected (fail fast)
+ *   HALF_OPEN — one probe request is allowed through to test recovery
+ *
+ * Transitions:
+ *   CLOSED → OPEN:      after `failureThreshold` consecutive failures
+ *   OPEN → HALF_OPEN:   after `resetTimeoutMs` elapses
+ *   HALF_OPEN → CLOSED: if the probe request succeeds
+ *   HALF_OPEN → OPEN:   if the probe request fails
+ */
+export class CircuitBreaker {
+  constructor(fn, { failureThreshold = 3, resetTimeoutMs = 2000 } = {}) {
+    this.fn = fn;
+    this.failureThreshold = failureThreshold;
+    this.resetTimeoutMs = resetTimeoutMs;
+    this.state = 'CLOSED';
+    this.failureCount = 0;
+    this.lastFailureTime = null;
+  }
+
+  async call(...args) {
+    if (this.state === 'OPEN') {
+      if (Date.now() - this.lastFailureTime >= this.resetTimeoutMs) {
+        this.state = 'HALF_OPEN';
+      } else {
+        throw new CircuitOpenError('Circuit breaker is OPEN');
+      }
+    }
+
+    try {
+      const result = await this.fn(...args);
+      this._onSuccess();
+      return result;
+    } catch (err) {
+      this._onFailure();
+      throw err;
+    }
+  }
+
+  _onSuccess() {
+    this.failureCount = 0;
+    this.state = 'CLOSED';
+  }
+
+  _onFailure() {
+    this.failureCount++;
+    this.lastFailureTime = Date.now();
+    if (this.failureCount >= this.failureThreshold) {
+      this.state = 'OPEN';
+    }
+  }
+}
+
+export class CircuitOpenError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}

--- a/examples/nodejs/src/upstream-server.js
+++ b/examples/nodejs/src/upstream-server.js
@@ -1,0 +1,47 @@
+/**
+ * Minimal upstream server that simulates a product API.
+ * Used as the proxy's upstream target for fault injection tests.
+ *
+ * Usage: node src/upstream-server.js [port]
+ */
+
+import { createServer } from 'node:http';
+
+const PORT = parseInt(process.argv[2] || '8080', 10);
+
+const products = {
+  '1':  { id: 1, name: 'Widget',  price: 9.99 },
+  '42': { id: 42, name: 'Gadget', price: 19.99 },
+};
+
+const server = createServer((req, res) => {
+  const match = req.url.match(/^\/products\/(.+)/);
+  if (match) {
+    const product = products[match[1]];
+    if (product) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(product));
+    } else {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Product not found' }));
+    }
+    return;
+  }
+
+  if (req.url === '/products') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(Object.values(products)));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Upstream server listening on port ${PORT}`);
+});
+
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
+});

--- a/examples/nodejs/test/proxy.test.js
+++ b/examples/nodejs/test/proxy.test.js
@@ -1,0 +1,248 @@
+/**
+ * Proxy-based fault injection scenario tests.
+ *
+ * Each test follows a realistic pattern: the application starts working
+ * normally, then a fault is injected mid-flight, and we verify both the
+ * failure behavior and the recovery.
+ *
+ * Setup (Docker):
+ *   cd examples/nodejs
+ *   docker compose up -d       # starts upstream + rodriguez with proxy
+ *   npm test -- proxy.test.js  # run only this test file
+ *   docker compose down        # cleanup
+ *
+ * Setup (local, no Docker):
+ *   node examples/nodejs/src/upstream-server.js 8080                              # terminal 1
+ *   mvn exec:java -pl rodriguez-build -Dexec.args="-c examples/nodejs/rodriguez-proxy.json"  # terminal 2
+ *   cd examples/nodejs && npm test -- proxy.test.js                               # terminal 3
+ */
+
+import { describe, test, expect, afterEach } from 'vitest';
+import { ProductClient, ProductApiError } from '../src/product-client.js';
+import { CircuitBreaker, CircuitOpenError } from '../src/circuit-breaker.js';
+
+const PROXY_PORT = 10220;
+const PROXY_API = `http://localhost:${PROXY_PORT}/_proxy/api`;
+
+const client = new ProductClient(`http://localhost:${PROXY_PORT}`, {
+  timeoutMs: 3000,
+});
+
+// --- Proxy API helpers (used only by test setup/teardown) ---
+
+async function injectFault({ pathPattern, faultType, count = 1, duration }) {
+  const body = { pathPattern, faultType, count };
+  if (duration) body.duration = duration;
+  const res = await fetch(`${PROXY_API}/rules`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Failed to inject fault: ${await res.text()}`);
+  return res.json();
+}
+
+async function clearFaults() {
+  await fetch(`${PROXY_API}/rules`, { method: 'DELETE' });
+}
+
+// --- Scenario tests ---
+
+describe('Fault injection via proxy', () => {
+  afterEach(async () => {
+    await clearFaults();
+  });
+
+  test('transient failure: service works, breaks briefly, then recovers', async () => {
+    // 1. Normal operation — requests succeed
+    const product = await client.getProduct('42');
+    expect(product.id).toBe(42);
+    expect(product.name).toBe('Gadget');
+
+    // 2. Inject a transient fault — next 2 requests return broken JSON
+    await injectFault({
+      pathPattern: '/products/.*',
+      faultType: 'BrokenJson',
+      count: 2,
+    });
+
+    // 3. During fault — application sees parse errors
+    for (let i = 0; i < 2; i++) {
+      await expect(client.getProduct('42')).rejects.toThrow(ProductApiError);
+    }
+
+    // 4. Recovery — fault rule exhausted, service is back to normal
+    const recovered = await client.getProduct('42');
+    expect(recovered.id).toBe(42);
+  });
+
+  test('auth outage: upstream auth service goes down and comes back', async () => {
+    // 1. Normal — authenticated requests work
+    const before = await client.getProduct('1');
+    expect(before.name).toBe('Widget');
+
+    // 2. Auth outage begins — next 3 requests get 401
+    await injectFault({
+      pathPattern: '/products/.*',
+      faultType: 'RefuseAuthentication',
+      count: 3,
+    });
+
+    // 3. Application should detect unauthorized errors
+    for (let i = 0; i < 3; i++) {
+      try {
+        await client.getProduct('1');
+        throw new Error('Expected UNAUTHORIZED');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProductApiError);
+        expect(err.code).toBe('UNAUTHORIZED');
+      }
+    }
+
+    // 4. Auth service recovers — requests succeed again
+    const after = await client.getProduct('1');
+    expect(after.name).toBe('Widget');
+  });
+
+  test('partial outage: one endpoint fails while another keeps working', async () => {
+    // 1. Both endpoints work
+    const product1 = await client.getProduct('1');
+    const product42 = await client.getProduct('42');
+    expect(product1.name).toBe('Widget');
+    expect(product42.name).toBe('Gadget');
+
+    // 2. Inject fault only on product 42's path
+    await injectFault({
+      pathPattern: '/products/42',
+      faultType: 'BrokenJson',
+      count: 5,
+    });
+
+    // 3. Product 1 is unaffected — still works fine
+    const stillWorking = await client.getProduct('1');
+    expect(stillWorking.name).toBe('Widget');
+
+    // 4. Product 42 is broken
+    await expect(client.getProduct('42')).rejects.toThrow(ProductApiError);
+
+    // 5. After fault expires, product 42 also recovers
+    // (consume the remaining 4 fault hits)
+    for (let i = 0; i < 4; i++) {
+      try { await client.getProduct('42'); } catch { /* expected */ }
+    }
+    const recovered42 = await client.getProduct('42');
+    expect(recovered42.name).toBe('Gadget');
+  });
+
+  test('time-bounded outage: fault auto-resolves after duration', async () => {
+    // 1. Normal operation
+    const before = await client.getProduct('1');
+    expect(before.name).toBe('Widget');
+
+    // 2. Inject fault with 1-second TTL
+    await injectFault({
+      pathPattern: '/products/.*',
+      faultType: 'BrokenJson',
+      count: 1000,    // high count — won't expire by usage
+      duration: '1s', // expires after 1 second regardless
+    });
+
+    // 3. During outage — requests fail
+    await expect(client.getProduct('1')).rejects.toThrow(ProductApiError);
+
+    // 4. Wait for TTL to expire
+    await new Promise(r => setTimeout(r, 1500));
+
+    // 5. Service auto-recovers without manual intervention
+    const after = await client.getProduct('1');
+    expect(after.name).toBe('Widget');
+  });
+
+  test('cascading failures: different fault types hit in sequence', async () => {
+    // 1. Normal operation
+    const before = await client.getProduct('42');
+    expect(before.name).toBe('Gadget');
+
+    // 2. First problem: upstream returns garbage JSON for 2 requests
+    await injectFault({
+      pathPattern: '/products/.*',
+      faultType: 'BrokenJson',
+      count: 2,
+    });
+
+    // 3. Then: upstream starts rejecting auth for 2 more requests
+    await injectFault({
+      pathPattern: '/products/.*',
+      faultType: 'RefuseAuthentication',
+      count: 2,
+    });
+
+    // 4. First wave — parse errors
+    for (let i = 0; i < 2; i++) {
+      try {
+        await client.getProduct('42');
+        throw new Error('Expected error');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProductApiError);
+        expect(err.code).toBe('INVALID_JSON');
+      }
+    }
+
+    // 5. Second wave — auth errors (different failure mode)
+    for (let i = 0; i < 2; i++) {
+      try {
+        await client.getProduct('42');
+        throw new Error('Expected error');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProductApiError);
+        expect(err.code).toBe('UNAUTHORIZED');
+      }
+    }
+
+    // 6. Full recovery
+    const after = await client.getProduct('42');
+    expect(after.name).toBe('Gadget');
+  });
+
+  test('circuit breaker: opens on failures, rejects fast, then recovers', async () => {
+    // Wrap the client call in a circuit breaker:
+    //   - opens after 3 consecutive failures
+    //   - tries recovery probe after 1 second
+    const breaker = new CircuitBreaker(
+      (id) => client.getProduct(id),
+      { failureThreshold: 3, resetTimeoutMs: 1000 },
+    );
+
+    // 1. Normal operation — circuit is CLOSED
+    const product = await breaker.call('1');
+    expect(product.name).toBe('Widget');
+    expect(breaker.state).toBe('CLOSED');
+
+    // 2. Inject sustained fault
+    await injectFault({
+      pathPattern: '/products/.*',
+      faultType: 'BrokenJson',
+      count: 10,
+    });
+
+    // 3. First 3 failures trip the circuit breaker to OPEN
+    for (let i = 0; i < 3; i++) {
+      await expect(breaker.call('1')).rejects.toThrow(ProductApiError);
+    }
+    expect(breaker.state).toBe('OPEN');
+
+    // 4. While OPEN — requests are rejected immediately without hitting upstream
+    await expect(breaker.call('1')).rejects.toThrow(CircuitOpenError);
+
+    // 5. Clear the fault (simulate upstream recovery)
+    await clearFaults();
+
+    // 6. Wait for reset timeout — circuit transitions to HALF_OPEN
+    await new Promise(r => setTimeout(r, 1200));
+
+    // 7. HALF_OPEN probe succeeds → circuit closes
+    const recovered = await breaker.call('1');
+    expect(recovered.name).toBe('Widget');
+    expect(breaker.state).toBe('CLOSED');
+  });
+});

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,33 @@
+# Rodriguez Python Examples
+
+Fault injection tests using `requests` and `boto3` against Rodriguez.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run Tests
+
+Requires Rodriguez running via Docker:
+
+```bash
+docker compose up -d   # from project root
+pytest -v
+```
+
+## What These Tests Demonstrate
+
+### HTTP Client (`requests`)
+
+- TCP-level faults: connection refused, connection timeout, RST packet, silent accept
+- HTTP-level faults: slow response, broken JSON, content type mismatch, oversized response, 401
+
+**Key pitfall**: `requests.get(url, timeout=5)` sets *both* connect and read timeout to 5s.
+Use `timeout=(connect, read)` tuple for independent control.
+
+### AWS S3 (`boto3`)
+
+- S3 operations against Rodriguez S3Mock (port 10213)
+- Timeout configuration via `botocore.config.Config`

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+boto3>=1.34.0
+pytest>=8.0.0

--- a/examples/python/src/product_client.py
+++ b/examples/python/src/product_client.py
@@ -1,0 +1,75 @@
+import requests
+
+
+class ProductApiError(Exception):
+    def __init__(self, message, *, code=None, status=None):
+        super().__init__(message)
+        self.code = code
+        self.status = status
+
+
+class ProductClient:
+    def __init__(self, base_url, *, timeout=(5, 5), max_response_bytes=1024 * 1024):
+        """
+        Args:
+            base_url: Base URL of the product API.
+            timeout: (connect_timeout, read_timeout) in seconds.
+            max_response_bytes: Maximum response body size in bytes.
+        """
+        self.base_url = base_url
+        self.timeout = timeout
+        self.max_response_bytes = max_response_bytes
+
+    def get_product(self, product_id):
+        return self._request(f"{self.base_url}/products/{product_id}")
+
+    def list_products(self):
+        return self._request(f"{self.base_url}/products")
+
+    def _request(self, url):
+        try:
+            response = requests.get(
+                url,
+                timeout=self.timeout,
+                headers={"Accept": "application/json"},
+                stream=True,
+            )
+        except requests.exceptions.ConnectTimeout:
+            raise ProductApiError("Connection timed out", code="CONNECT_TIMEOUT")
+        except requests.exceptions.ReadTimeout:
+            raise ProductApiError("Read timed out", code="READ_TIMEOUT")
+        except requests.exceptions.ConnectionError as e:
+            raise ProductApiError(f"Connection failed: {e}", code="CONNECTION_ERROR")
+
+        if response.status_code == 401:
+            raise ProductApiError("Authentication failed", code="UNAUTHORIZED", status=401)
+
+        if not response.ok:
+            raise ProductApiError(f"HTTP {response.status_code}", code="HTTP_ERROR", status=response.status_code)
+
+        content_type = response.headers.get("content-type", "")
+        body = self._read_body_with_limit(response)
+
+        if "application/json" not in content_type:
+            raise ProductApiError(
+                f"Unexpected content type: {content_type}", code="INVALID_CONTENT_TYPE"
+            )
+
+        try:
+            return response.json()
+        except ValueError:
+            raise ProductApiError("Invalid JSON in response body", code="INVALID_JSON")
+
+    def _read_body_with_limit(self, response):
+        total = 0
+        chunks = []
+        for chunk in response.iter_content(chunk_size=4096):
+            total += len(chunk)
+            if total > self.max_response_bytes:
+                response.close()
+                raise ProductApiError(
+                    f"Response body exceeds {self.max_response_bytes} bytes",
+                    code="RESPONSE_TOO_LARGE",
+                )
+            chunks.append(chunk)
+        return b"".join(chunks)

--- a/examples/python/tests/test_product_client.py
+++ b/examples/python/tests/test_product_client.py
@@ -1,0 +1,142 @@
+"""
+Fault injection tests for ProductClient using Rodriguez.
+
+Requires Rodriguez running on default ports (docker compose up -d).
+"""
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.product_client import ProductClient, ProductApiError
+
+PORTS = {
+    "REFUSE_CONNECTION": 10201,
+    "NOT_ACCEPT": 10202,
+    "RST_AFTER_DELAY": 10203,
+    "NEVER_DRAIN": 10204,
+    "SLOW_RESPONSE": 10205,
+    "CONTENT_TYPE_MISMATCH": 10206,
+    "RESPONSE_HEADER_ONLY": 10207,
+    "BROKEN_JSON": 10208,
+    "ACCEPT_BUT_SILENT": 10209,
+    "OVERSIZED_RESPONSE": 10211,
+    "REFUSE_AUTH": 10212,
+}
+
+
+def client_for(port, **kwargs):
+    timeout = kwargs.pop("timeout", (1, 2))
+    return ProductClient(f"http://localhost:{port}", timeout=timeout, **kwargs)
+
+
+# --- TCP-level faults ---
+
+
+class TestRefuseConnection:
+    def test_throws_connection_error(self):
+        client = client_for(PORTS["REFUSE_CONNECTION"], timeout=(1, 1))
+        with pytest.raises(ProductApiError, match="Connection failed") as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "CONNECTION_ERROR"
+
+
+class TestNotAccept:
+    def test_throws_connect_timeout(self):
+        client = client_for(PORTS["NOT_ACCEPT"], timeout=(1, 1))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code in ("CONNECT_TIMEOUT", "CONNECTION_ERROR")
+
+
+class TestNoResponseAndSendRST:
+    def test_throws_connection_error(self):
+        client = client_for(PORTS["RST_AFTER_DELAY"], timeout=(5, 5))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "CONNECTION_ERROR"
+
+
+class TestNeverDrain:
+    def test_throws_timeout_or_connection_error(self):
+        client = client_for(PORTS["NEVER_DRAIN"], timeout=(1, 2))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code in ("CONNECT_TIMEOUT", "READ_TIMEOUT", "CONNECTION_ERROR")
+
+
+class TestAcceptButSilent:
+    def test_throws_read_timeout(self):
+        client = client_for(PORTS["ACCEPT_BUT_SILENT"], timeout=(1, 2))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "READ_TIMEOUT"
+
+
+# --- HTTP-level faults ---
+
+
+class TestSlowResponse:
+    """
+    Key pitfall: requests' timeout=(connect, read) applies the read timeout
+    per chunk, not for the total transfer. A SlowResponse that drips data
+    1 byte/second may never trigger ReadTimeout if each byte arrives within
+    the read timeout window.
+    """
+
+    def test_slow_body_may_not_timeout_with_per_chunk_read_timeout(self):
+        # read timeout of 2s per chunk — SlowResponse sends 1 byte/sec,
+        # which is within the per-chunk deadline
+        client = client_for(PORTS["SLOW_RESPONSE"], timeout=(1, 2))
+        # This may NOT raise ReadTimeout because each individual chunk
+        # arrives within 2s. This is a key difference from Node.js where
+        # AbortSignal.timeout covers the entire request.
+        # We just verify the request eventually completes or errors.
+        with pytest.raises(ProductApiError):
+            client.get_product("1")
+
+
+class TestResponseHeaderOnly:
+    def test_throws_read_timeout(self):
+        client = client_for(PORTS["RESPONSE_HEADER_ONLY"], timeout=(1, 2))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "READ_TIMEOUT"
+
+
+class TestBrokenJson:
+    def test_throws_invalid_json(self):
+        client = client_for(PORTS["BROKEN_JSON"], timeout=(1, 5))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "INVALID_JSON"
+
+
+class TestContentTypeMismatch:
+    def test_throws_invalid_content_type(self):
+        client = client_for(PORTS["CONTENT_TYPE_MISMATCH"], timeout=(1, 5))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "INVALID_CONTENT_TYPE"
+
+
+class TestOversizedResponse:
+    def test_throws_response_too_large(self):
+        client = client_for(
+            PORTS["OVERSIZED_RESPONSE"],
+            timeout=(1, 10),
+            max_response_bytes=1024,
+        )
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "RESPONSE_TOO_LARGE"
+
+
+class TestRefuseAuthentication:
+    def test_throws_unauthorized(self):
+        client = client_for(PORTS["REFUSE_AUTH"], timeout=(1, 5))
+        with pytest.raises(ProductApiError) as exc_info:
+            client.get_product("1")
+        assert exc_info.value.code == "UNAUTHORIZED"
+        assert exc_info.value.status == 401

--- a/examples/python/tests/test_s3.py
+++ b/examples/python/tests/test_s3.py
@@ -1,0 +1,107 @@
+"""
+S3 fault injection tests using boto3 against Rodriguez S3Mock.
+
+Requires Rodriguez running on default ports (docker compose up -d).
+"""
+
+import pytest
+import boto3
+from botocore.config import Config
+from botocore.exceptions import (
+    ConnectTimeoutError,
+    ReadTimeoutError,
+    EndpointConnectionError,
+)
+
+S3_PORT = 10213
+
+PORTS = {
+    "REFUSE_CONNECTION": 10201,
+    "NOT_ACCEPT": 10202,
+    "SLOW_RESPONSE": 10205,
+}
+
+
+def s3_client(port=S3_PORT, connect_timeout=2, read_timeout=5, retries=0):
+    return boto3.client(
+        "s3",
+        endpoint_url=f"http://localhost:{port}",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name="us-east-1",
+        config=Config(
+            connect_timeout=connect_timeout,
+            read_timeout=read_timeout,
+            retries={"max_attempts": retries},
+        ),
+    )
+
+
+class TestS3MockBasicOperations:
+    """Verify S3Mock works correctly before testing faults."""
+
+    def test_create_and_list_buckets(self):
+        client = s3_client()
+        bucket_name = "pytest-test-bucket"
+
+        client.create_bucket(Bucket=bucket_name)
+
+        response = client.list_buckets()
+        bucket_names = [b["Name"] for b in response["Buckets"]]
+        assert bucket_name in bucket_names
+
+        client.delete_bucket(Bucket=bucket_name)
+
+    def test_put_and_get_object(self):
+        client = s3_client()
+        bucket_name = "pytest-object-test"
+        client.create_bucket(Bucket=bucket_name)
+
+        client.put_object(Bucket=bucket_name, Key="hello.txt", Body=b"Hello, Rodriguez!")
+
+        response = client.get_object(Bucket=bucket_name, Key="hello.txt")
+        body = response["Body"].read()
+        assert body == b"Hello, Rodriguez!"
+
+        # Cleanup
+        client.delete_object(Bucket=bucket_name, Key="hello.txt")
+        client.delete_bucket(Bucket=bucket_name)
+
+
+class TestS3ConnectionRefused:
+    """boto3 raises EndpointConnectionError when connection is refused."""
+
+    def test_raises_endpoint_connection_error(self):
+        client = s3_client(port=PORTS["REFUSE_CONNECTION"], retries=0)
+        with pytest.raises(EndpointConnectionError):
+            client.list_buckets()
+
+
+class TestS3ConnectionTimeout:
+    """
+    boto3 raises ConnectTimeoutError when server never accepts.
+
+    Key pitfall: boto3's default retry count is 3 (standard mode) or 5 (adaptive).
+    Without setting retries=0, a ConnectTimeout test with a 2s connect timeout
+    could wait up to 8s (2s * 4 attempts).
+    """
+
+    def test_raises_connect_timeout(self):
+        client = s3_client(port=PORTS["NOT_ACCEPT"], connect_timeout=1, retries=0)
+        with pytest.raises(ConnectTimeoutError):
+            client.list_buckets()
+
+
+class TestS3SlowResponse:
+    """
+    boto3 raises ReadTimeoutError when response body is too slow.
+
+    Key pitfall: boto3's read_timeout applies per socket recv() call,
+    not total transfer time. SlowResponse dripping 1 byte/sec may not
+    trigger ReadTimeoutError if each byte arrives within the timeout.
+    """
+
+    def test_raises_read_timeout_with_short_timeout(self):
+        client = s3_client(port=PORTS["SLOW_RESPONSE"], read_timeout=1, retries=0)
+        with pytest.raises(ReadTimeoutError):
+            client.list_buckets()

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
-        <junit.version>5.11.4</junit.version>
+        <junit.version>5.14.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <picocli.version>4.7.7</picocli.version>
         <jackson.version>2.21.1</jackson.version>
         <failsafe.version>3.3.2</failsafe.version>
-        <hikaricp.version>6.2.1</hikaricp.version>
+        <hikaricp.version>6.3.3</hikaricp.version>
         <slf4j.version>2.0.17</slf4j.version>
         <jsqlparser.version>4.9</jsqlparser.version>
     </properties>

--- a/rodriguez-build/pom.xml
+++ b/rodriguez-build/pom.xml
@@ -26,6 +26,16 @@
                 <configuration>
                     <from>
                         <image>gcr.io/distroless/java21-debian12</image>
+                        <platforms>
+                            <platform>
+                                <architecture>amd64</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>arm64</architecture>
+                                <os>linux</os>
+                            </platform>
+                        </platforms>
                     </from>
                     <to>
                         <image>docker.io/kawasima/rodriguez</image>

--- a/rodriguez-gcp/README.md
+++ b/rodriguez-gcp/README.md
@@ -1,0 +1,81 @@
+# rodriguez-gcp
+
+Mock implementation of the Google Cloud Storage (GCS) JSON API v1 for testing GCS client interactions without connecting to real Google Cloud infrastructure.
+
+## Default Port
+
+| Port  | Behavior |
+| ----- | -------- |
+| 10215 | GCSMock  |
+
+## Supported Operations
+
+| Operation        | Method   | Endpoint                                              |
+| ---------------- | -------- | ----------------------------------------------------- |
+| Create Bucket    | `POST`   | `/storage/v1/b?project={project}`                     |
+| List Buckets     | `GET`    | `/storage/v1/b?project={project}`                     |
+| Delete Bucket    | `DELETE` | `/storage/v1/b/{bucket}`                              |
+| Upload Object    | `POST`   | `/upload/storage/v1/b/{bucket}/o?uploadType=media`    |
+| List Objects     | `GET`    | `/storage/v1/b/{bucket}/o`                            |
+| Get Metadata     | `GET`    | `/storage/v1/b/{bucket}/o/{object}`                   |
+| Download Object  | `GET`    | `/storage/v1/b/{bucket}/o/{object}?alt=media`         |
+| Delete Object    | `DELETE` | `/storage/v1/b/{bucket}/o/{object}`                   |
+
+Both `uploadType=media` (raw body) and `uploadType=multipart` (JSON metadata + binary) are supported for uploads.
+
+## Storage
+
+Objects are stored on the local filesystem in a temporary directory created on first request.
+Each bucket maps to a subdirectory, and objects are stored as files within it.
+The directory is automatically cleaned up on JVM exit.
+
+MD5 and CRC32C checksums are computed per object during upload for client-side validation.
+
+## Configuration
+
+```json
+{
+  "ports": {
+    "10215": {
+      "type": "GCSMock"
+    }
+  }
+}
+```
+
+## Client Configuration
+
+Point the GCS client to `http://localhost:10215` (or your configured port).
+
+### Java
+
+```java
+Storage storage = StorageOptions.newBuilder()
+    .setHost("http://localhost:10215")
+    .setProjectId("test-project")
+    .build()
+    .getService();
+```
+
+### Node.js
+
+```javascript
+const { Storage } = require('@google-cloud/storage');
+const storage = new Storage({
+  apiEndpoint: 'http://localhost:10215',
+  projectId: 'test-project',
+});
+```
+
+### Python
+
+```python
+from google.cloud import storage
+
+client = storage.Client(
+    project="test-project",
+    client_options={"api_endpoint": "http://localhost:10215"},
+)
+```
+
+The mock ignores authentication credentials, so any auth configuration will be accepted.

--- a/rodriguez-jdbc/README.md
+++ b/rodriguez-jdbc/README.md
@@ -1,23 +1,114 @@
 # rodriguez-jdbc
 
-Rodriguez supports JDBC Harness.
+JDBC driver mock that returns CSV fixture data with configurable execution and iteration delays. Useful for testing slow query handling, connection pool exhaustion, and timeout behavior.
 
-## Usage
+## Default Port
 
-Set a JDBC URL `jdbc:rodriguez://localhost:10202`.
+| Port  | Behavior     |
+| ----- | ------------ |
+| 10210 | MockDatabase |
 
-### JDBC
+## JDBC URL
+
+```
+jdbc:rodriguez://localhost:10210
+```
+
+The driver class `net.unit8.rodriguez.jdbc.RodriguezDriver` is auto-registered via `ServiceLoader`.
+
+## Configuration
+
+```json
+{
+  "ports": {
+    "10210": {
+      "type": "MockDatabase",
+      "dataDirectory": "data",
+      "delayExecution": 1000,
+      "delayResultSetNext": 200
+    }
+  }
+}
+```
+
+| Field               | Default | Description                                       |
+| ------------------- | ------- | ------------------------------------------------- |
+| `dataDirectory`     | `data`  | Path to directory containing CSV fixture files    |
+| `delayExecution`    | 1000    | Delay in ms before returning query results        |
+| `delayResultSetNext`| 200     | Delay in ms for each `ResultSet.next()` call      |
+
+## Fixture Files
+
+Query results are loaded from CSV files. The file name is the **SHA-1 hash** of the SQL statement.
+
+### Creating a Fixture
+
+1. Compute the SHA-1 of your SQL:
+
+```bash
+echo -n "SELECT id, name FROM emp" | sha1sum
+# Output: 500b40b481688654ffa6b607ffdf8df4e2fe420f
+```
+
+2. Create a CSV file named `{hash}.csv` in the data directory:
+
+```csv
+id,name
+1,Alice
+2,Bob
+3,Charlie
+```
+
+The first row is the header (column names). Subsequent rows are the data.
+
+### File Location
+
+Place fixture files in the `dataDirectory` path. The default is `data/` relative to the working directory.
+
+```
+data/
+  500b40b481688654ffa6b607ffdf8df4e2fe420f.csv
+  a1b2c3d4e5f6....csv
+```
+
+## Java Usage
 
 ```java
-    HarnessConfig config = new HarnessConfig();
-    config.setPorts(Map.of(10201, new MockDatabase()));
-    harnessServer = new HarnessServer(config);
-    harnessServer.start();
+// Start the harness
+HarnessConfig config = new HarnessConfig();
+MockDatabase mockDb = new MockDatabase();
+mockDb.setDataDirectory("src/test/resources/data");
+mockDb.setDelayExecution(500);
+config.setPorts(Map.of(10210, mockDb));
+HarnessServer server = new HarnessServer(config);
+server.start();
+
+// Use standard JDBC
+try (Connection conn = DriverManager.getConnection("jdbc:rodriguez://localhost:10210");
+     PreparedStatement ps = conn.prepareStatement("SELECT id, name FROM emp");
+     ResultSet rs = ps.executeQuery()) {
+    while (rs.next()) {
+        System.out.println(rs.getInt("id") + ": " + rs.getString("name"));
+    }
+}
 ```
 
-ResultSet data
+### With HikariCP
 
-```
-% echo -n "SELECT id, name FROM emp" | sha1sum
+```java
+HikariConfig hikariConfig = new HikariConfig();
+hikariConfig.setJdbcUrl("jdbc:rodriguez://localhost:10210");
+hikariConfig.setMaximumPoolSize(5);
+hikariConfig.setConnectionTimeout(3000);
+
+try (HikariDataSource ds = new HikariDataSource(hikariConfig);
+     Connection conn = ds.getConnection()) {
+    // ...
+}
 ```
 
+## Testing Scenarios
+
+- **Slow query**: Set `delayExecution` to a value exceeding your application's query timeout
+- **Slow iteration**: Set `delayResultSetNext` to simulate large result set reads
+- **Connection pool exhaustion**: Set high delays and open many connections to exhaust pool limits

--- a/rodriguez-jdbc/src/main/java/net/unit8/rodriguez/jdbc/impl/CallableStatementImpl.java
+++ b/rodriguez-jdbc/src/main/java/net/unit8/rodriguez/jdbc/impl/CallableStatementImpl.java
@@ -859,12 +859,12 @@ public class CallableStatementImpl extends StatementImpl implements CallableStat
     }
 
     public boolean isWrapperFor(Class<?> iface) throws java.sql.SQLException {
-        // TODO Auto-generated method stub
+
         return iface != null && iface.isAssignableFrom(this.getClass());
     }
 
     public <T> T unwrap(Class<T> iface) throws java.sql.SQLException {
-        // TODO Auto-generated method stub
+
         try {
             if (iface != null && iface.isAssignableFrom(this.getClass())) {
                 return (T) this;
@@ -876,11 +876,11 @@ public class CallableStatementImpl extends StatementImpl implements CallableStat
     }
 
     public void closeOnCompletion() {
-        // TODO Auto-generated method stub
+
     }
 
     public boolean isCloseOnCompletion() {
-        // TODO Auto-generated method stub
+
         return false;
     }
 }

--- a/rodriguez-jdbc/src/main/java/net/unit8/rodriguez/jdbc/impl/PreparedStatementImpl.java
+++ b/rodriguez-jdbc/src/main/java/net/unit8/rodriguez/jdbc/impl/PreparedStatementImpl.java
@@ -320,12 +320,12 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
     }
 
     public boolean isWrapperFor(Class<?> iface) throws java.sql.SQLException {
-        // TODO Auto-generated method stub
+
         return iface != null && iface.isAssignableFrom(this.getClass());
     }
 
     public <T> T unwrap(Class<T> iface) throws java.sql.SQLException {
-        // TODO Auto-generated method stub
+
         try {
             if (iface != null && iface.isAssignableFrom(this.getClass())) {
                 return (T) this;
@@ -337,11 +337,11 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
     }
 
     public void closeOnCompletion() {
-        // TODO Auto-generated method stub
+
     }
 
     public boolean isCloseOnCompletion() {
-        // TODO Auto-generated method stub
+
         return false;
     }
 }

--- a/rodriguez-jdbc/src/main/java/net/unit8/rodriguez/jdbc/impl/TypeConverter.java
+++ b/rodriguez-jdbc/src/main/java/net/unit8/rodriguez/jdbc/impl/TypeConverter.java
@@ -107,10 +107,10 @@ public class TypeConverter {
      * Converts a string to a byte array.
      *
      * @param s the string to convert
-     * @return the byte array, or {@code null} (not yet implemented)
+     * @return the byte array in UTF-8 encoding
      */
     public static byte[] toBytes(String s) {
-        return null; // FIXME
+        return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
     }
 
     /**

--- a/rodriguez-proxy/README.md
+++ b/rodriguez-proxy/README.md
@@ -1,0 +1,166 @@
+# rodriguez-proxy
+
+A fault-injecting reverse proxy extension for Rodriguez. Routes requests to an upstream service and selectively injects faults by forwarding matching paths to Rodriguez behavior ports.
+
+Includes a drag-and-drop web UI dashboard and a REST API for programmatic rule management from test code.
+
+## Configuration
+
+The proxy is configured as a Rodriguez extension:
+
+```json
+{
+  "extensions": {
+    "proxy": {
+      "port": 10220,
+      "upstream": "http://localhost:8080",
+      "connectTimeoutMs": 5000,
+      "requestTimeoutMs": 30000,
+      "controlUrl": "http://localhost:10200",
+      "paths": ["/api/.*", "/health"]
+    }
+  }
+}
+```
+
+| Field             | Default                      | Description                              |
+| ----------------- | ---------------------------- | ---------------------------------------- |
+| `port`            | 10220                        | Port the proxy listens on                |
+| `upstream`        | (required)                   | Upstream service URL                     |
+| `connectTimeoutMs`| 5000                         | Connection timeout in milliseconds       |
+| `requestTimeoutMs`| 30000                        | Request timeout in milliseconds          |
+| `controlUrl`      | `http://localhost:10200`     | Rodriguez control API URL                |
+| `paths`           | (optional)                   | Path prefixes to display in the UI       |
+
+## REST API
+
+All API endpoints support CORS (`Access-Control-Allow-Origin: *`).
+
+### List Rules
+
+```
+GET /_proxy/api/rules
+```
+
+Returns all active fault injection rules.
+
+### Create Rule
+
+```
+POST /_proxy/api/rules
+Content-Type: application/json
+```
+
+```json
+{
+  "pathPattern": "/api/users/.*",
+  "faultType": "SlowResponse",
+  "faultPort": 10205,
+  "count": 5,
+  "duration": "30s"
+}
+```
+
+| Field         | Required | Description                                                       |
+| ------------- | -------- | ----------------------------------------------------------------- |
+| `pathPattern` | yes      | Regex to match request paths                                      |
+| `faultType`   | yes      | Behavior name (e.g., `SlowResponse`, `BrokenJson`)                |
+| `faultPort`   | no       | Rodriguez port. If omitted, resolved automatically from faultType |
+| `count`       | no       | Number of requests to inject (default: 1)                         |
+| `duration`    | no       | TTL: `"30s"`, `"5m"`, `"1h"`. Rule expires after this time       |
+
+Response (201):
+
+```json
+{
+  "id": "abc-123",
+  "pathPattern": "/api/users/.*",
+  "faultType": "SlowResponse",
+  "faultPort": 10205,
+  "remaining": 5,
+  "duration": "PT30S"
+}
+```
+
+### Delete All Rules
+
+```
+DELETE /_proxy/api/rules
+```
+
+Removes all active rules. Useful for test teardown. Returns 204.
+
+### Delete Rule
+
+```
+DELETE /_proxy/api/rules/{id}
+```
+
+Returns 204.
+
+### Increment Rule Count
+
+```
+PATCH /_proxy/api/rules/{id}/increment
+```
+
+Atomically increments the remaining count.
+
+### List Behaviors
+
+```
+GET /_proxy/api/behaviors
+```
+
+Returns available fault behaviors discovered from the Rodriguez control API.
+
+### List Observed Paths
+
+```
+GET /_proxy/api/paths
+```
+
+Returns paths that have been successfully proxied (HTTP 200-399).
+
+## Server-Sent Events
+
+```
+GET /_proxy/events
+```
+
+Streams real-time rule lifecycle events.
+
+| Event Type      | Description                                    |
+| --------------- | ---------------------------------------------- |
+| `rule-added`    | A new rule was created                         |
+| `rule-consumed` | A rule matched a request (remaining decreased) |
+| `rule-removed`  | A rule was deleted or expired                  |
+| `path-observed` | A new path was successfully proxied            |
+
+## Web Dashboard
+
+Access the dashboard at `http://localhost:10220/_proxy/ui/`.
+
+Features:
+
+- Drag-and-drop fault behavior cards onto request paths
+- Real-time event log via SSE
+- Add custom path patterns
+- View and manage active rules
+
+## Usage from Test Code
+
+```bash
+# Inject a fault for the next 3 requests to /api/users
+curl -X POST http://localhost:10220/_proxy/api/rules \
+  -H 'Content-Type: application/json' \
+  -d '{"pathPattern":"/api/users/.*","faultType":"SlowResponse","count":3}'
+
+# Inject a fault with 30-second TTL
+curl -X POST http://localhost:10220/_proxy/api/rules \
+  -H 'Content-Type: application/json' \
+  -d '{"pathPattern":"/api/.*","faultType":"BrokenJson","count":100,"duration":"30s"}'
+
+# Clear all rules (test teardown)
+curl -X DELETE http://localhost:10220/_proxy/api/rules
+```

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/ApiHandler.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/ApiHandler.java
@@ -16,29 +16,32 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * REST API handler for managing fault injection rules.
  *
  * <p>Endpoints:
  * <ul>
- *   <li>GET  /_proxy/api/rules      — list active rules</li>
- *   <li>POST /_proxy/api/rules      — create a rule</li>
- *   <li>DELETE /_proxy/api/rules/{id} — remove a rule</li>
- *   <li>GET  /_proxy/api/behaviors  — list available fault behaviors (from control API)</li>
- *   <li>GET  /_proxy/api/paths      — list observed paths (HTTP 200-399)</li>
+ *   <li>GET    /_proxy/api/rules        — list active rules</li>
+ *   <li>POST   /_proxy/api/rules        — create a rule (faultPort is optional; resolved from faultType)</li>
+ *   <li>DELETE /_proxy/api/rules         — remove all rules</li>
+ *   <li>DELETE /_proxy/api/rules/{id}    — remove a rule by ID</li>
+ *   <li>GET    /_proxy/api/behaviors     — list available fault behaviors (from control API)</li>
+ *   <li>GET    /_proxy/api/paths         — list observed paths (HTTP 200-399)</li>
  * </ul>
  */
 public class ApiHandler implements HttpHandler {
+    private static final Logger LOG = Logger.getLogger(ApiHandler.class.getName());
     private final ObjectMapper mapper = new ObjectMapper();
     private final FaultRuleStore store;
     private final ProxyConfig config;
     private final ObservedPathStore observedPathStore;
     private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final Map<String, Integer> behaviorPortCache = new ConcurrentHashMap<>();
 
     /**
      * Creates a new API handler.
@@ -76,6 +79,8 @@ public class ApiHandler implements HttpHandler {
                         handleListRules(exchange);
                     } else if ("POST".equals(method)) {
                         handleCreateRule(exchange);
+                    } else if ("DELETE".equals(method)) {
+                        handleClearAllRules(exchange);
                     } else {
                         exchange.sendResponseHeaders(405, -1);
                     }
@@ -128,13 +133,31 @@ public class ApiHandler implements HttpHandler {
 
         String pathPattern = (String) json.get("pathPattern");
         String faultType = (String) json.get("faultType");
-        int faultPort = ((Number) json.get("faultPort")).intValue();
         int count = json.containsKey("count") ? ((Number) json.get("count")).intValue() : 1;
 
-        FaultRule rule = new FaultRule(pathPattern, faultType, faultPort, count);
+        int faultPort;
+        if (json.containsKey("faultPort")) {
+            faultPort = ((Number) json.get("faultPort")).intValue();
+        } else {
+            Integer resolved = resolveFaultPort(faultType);
+            if (resolved == null) {
+                sendJson(exchange, 400, mapper.writeValueAsBytes(
+                        Map.of("error", "Unknown faultType: " + faultType)));
+                return;
+            }
+            faultPort = resolved;
+        }
+
+        String duration = (String) json.get("duration");
+        FaultRule rule = new FaultRule(pathPattern, faultType, faultPort, count, duration);
         store.addRule(rule);
 
         sendJson(exchange, 201, mapper.writeValueAsBytes(ruleToMap(rule)));
+    }
+
+    private void handleClearAllRules(HttpExchange exchange) throws IOException {
+        store.clearAll();
+        exchange.sendResponseHeaders(204, -1);
     }
 
     private void handleDeleteRule(HttpExchange exchange, String ruleId) throws IOException {
@@ -180,6 +203,33 @@ public class ApiHandler implements HttpHandler {
         sendJson(exchange, 200, mapper.writeValueAsBytes(observedPathStore.getPaths()));
     }
 
+    private Integer resolveFaultPort(String faultType) {
+        Integer cached = behaviorPortCache.get(faultType);
+        if (cached != null) {
+            return cached;
+        }
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(config.getControlUrl() + "/config"))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            JsonNode ports = mapper.readTree(response.body()).get("ports");
+            if (ports != null) {
+                ports.fields().forEachRemaining(entry -> {
+                    String type = entry.getValue().path("type").asText();
+                    behaviorPortCache.put(type, Integer.parseInt(entry.getKey()));
+                });
+            }
+        } catch (IOException | InterruptedException e) {
+            LOG.log(Level.WARNING, "Failed to fetch behaviors from control API", e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return behaviorPortCache.get(faultType);
+    }
+
     private Map<String, Object> ruleToMap(FaultRule rule) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("id", rule.getId());
@@ -187,6 +237,9 @@ public class ApiHandler implements HttpHandler {
         map.put("faultType", rule.getFaultType());
         map.put("faultPort", rule.getFaultPort());
         map.put("remaining", rule.getRemaining());
+        if (rule.getDuration() != null) {
+            map.put("duration", rule.getDuration().toString());
+        }
         return map;
     }
 

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/model/FaultRule.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/model/FaultRule.java
@@ -1,7 +1,10 @@
 package net.unit8.rodriguez.proxy.model;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -9,14 +12,19 @@ import java.util.regex.Pattern;
  *
  * <p>Each rule has a countdown ({@code remaining}) that decrements on each match.
  * When the count reaches zero, the rule is automatically removed by the store.
+ * An optional {@code duration} causes the rule to expire after the specified time.
  */
 public class FaultRule {
+    private static final Pattern DURATION_SHORTHAND = Pattern.compile("(\\d+)([smh])");
+
     private final String id;
     private final String pathPattern;
     private final Pattern compiledPattern;
     private final String faultType;
     private final int faultPort;
     private final AtomicInteger remaining;
+    private final Instant createdAt;
+    private final Duration duration;
 
     /**
      * Creates a new fault rule.
@@ -27,12 +35,27 @@ public class FaultRule {
      * @param count       number of requests to inject the fault
      */
     public FaultRule(String pathPattern, String faultType, int faultPort, int count) {
+        this(pathPattern, faultType, faultPort, count, null);
+    }
+
+    /**
+     * Creates a new fault rule with an optional TTL duration.
+     *
+     * @param pathPattern    regex pattern to match request paths
+     * @param faultType      behavior name (e.g., "SlowResponse")
+     * @param faultPort      Rodriguez port to forward to (e.g., 10205)
+     * @param count          number of requests to inject the fault
+     * @param durationString TTL in shorthand format (e.g., "30s", "5m", "1h"), or null for no expiry
+     */
+    public FaultRule(String pathPattern, String faultType, int faultPort, int count, String durationString) {
         this.id = UUID.randomUUID().toString();
         this.pathPattern = pathPattern;
         this.compiledPattern = Pattern.compile(pathPattern);
         this.faultType = faultType;
         this.faultPort = faultPort;
         this.remaining = new AtomicInteger(count);
+        this.createdAt = Instant.now();
+        this.duration = parseDuration(durationString);
     }
 
     /**
@@ -106,5 +129,40 @@ public class FaultRule {
      */
     public int getRemaining() {
         return remaining.get();
+    }
+
+    /**
+     * Returns the TTL duration, or null if no expiry is set.
+     *
+     * @return the duration, or null
+     */
+    public Duration getDuration() {
+        return duration;
+    }
+
+    /**
+     * Returns whether this rule has expired based on its TTL duration.
+     *
+     * @return true if the rule has a duration set and has expired
+     */
+    public boolean isExpired() {
+        return duration != null && Instant.now().isAfter(createdAt.plus(duration));
+    }
+
+    private static Duration parseDuration(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        Matcher m = DURATION_SHORTHAND.matcher(s);
+        if (m.matches()) {
+            long value = Long.parseLong(m.group(1));
+            return switch (m.group(2)) {
+                case "s" -> Duration.ofSeconds(value);
+                case "m" -> Duration.ofMinutes(value);
+                case "h" -> Duration.ofHours(value);
+                default -> Duration.parse(s);
+            };
+        }
+        return Duration.parse(s);
     }
 }

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/store/FaultRuleStore.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/store/FaultRuleStore.java
@@ -101,7 +101,14 @@ public class FaultRuleStore {
     public Optional<FaultRule> findAndConsume(String path) {
         for (String id : ruleOrder) {
             FaultRule rule = rules.get(id);
-            if (rule != null && rule.matches(path)) {
+            if (rule == null) continue;
+            if (rule.isExpired()) {
+                rules.remove(id);
+                ruleOrder.remove(id);
+                listeners.forEach(l -> l.onRuleRemoved(rule));
+                continue;
+            }
+            if (rule.matches(path)) {
                 int remaining = rule.decrementAndGet();
                 if (remaining <= 0) {
                     rules.remove(id);
@@ -114,6 +121,16 @@ public class FaultRuleStore {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Removes all fault rules from the store.
+     */
+    public void clearAll() {
+        List<FaultRule> removed = new ArrayList<>(rules.values());
+        rules.clear();
+        ruleOrder.clear();
+        removed.forEach(rule -> listeners.forEach(l -> l.onRuleRemoved(rule)));
     }
 
     /**

--- a/rodriguez-proxy/src/test/java/net/unit8/rodriguez/proxy/ProxyServerTest.java
+++ b/rodriguez-proxy/src/test/java/net/unit8/rodriguez/proxy/ProxyServerTest.java
@@ -15,6 +15,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -263,5 +264,135 @@ class ProxyServerTest {
                 HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).isEqualTo(204);
+    }
+
+    // ---- API: faultType-only rule creation ----
+
+    @Test
+    void createRuleWithFaultTypeOnly() throws Exception {
+        String ruleBody = mapper.writeValueAsString(Map.of(
+                "pathPattern", "/api/auto-resolve",
+                "faultType", "SlowResponse",
+                "count", 1));
+
+        HttpResponse<String> createResponse = httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(ruleBody))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(createResponse.statusCode()).isEqualTo(201);
+        JsonNode created = mapper.readTree(createResponse.body());
+        assertThat(created.get("faultType").asText()).isEqualTo("SlowResponse");
+        assertThat(created.get("faultPort").asInt()).isEqualTo(FAULT_PORT);
+
+        // Cleanup
+        httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules/" + created.get("id").asText()))
+                        .DELETE()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    void createRuleWithUnknownFaultTypeReturns400() throws Exception {
+        String ruleBody = mapper.writeValueAsString(Map.of(
+                "pathPattern", "/api/unknown",
+                "faultType", "NonExistentBehavior",
+                "count", 1));
+
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(ruleBody))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        JsonNode json = mapper.readTree(response.body());
+        assertThat(json.get("error").asText()).contains("NonExistentBehavior");
+    }
+
+    // ---- API: bulk clear ----
+
+    @Test
+    void clearAllRules() throws Exception {
+        // Create two rules
+        for (String path : new String[]{"/api/clear-1", "/api/clear-2"}) {
+            httpClient.send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules"))
+                            .header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(Map.of(
+                                    "pathPattern", path,
+                                    "faultType", "SlowResponse",
+                                    "faultPort", FAULT_PORT,
+                                    "count", 10))))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+        }
+
+        // Clear all
+        HttpResponse<String> deleteResponse = httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules"))
+                        .DELETE()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(deleteResponse.statusCode()).isEqualTo(204);
+
+        // Verify empty
+        HttpResponse<String> listResponse = httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules"))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        JsonNode rules = mapper.readTree(listResponse.body());
+        assertThat(rules).isEmpty();
+    }
+
+    // ---- API: TTL duration ----
+
+    @Test
+    void ruleExpiresAfterDuration() throws Exception {
+        // Create a rule with 1-second TTL
+        Map<String, Object> ruleMap = new LinkedHashMap<>();
+        ruleMap.put("pathPattern", "/api/ttl-test");
+        ruleMap.put("faultType", "SlowResponse");
+        ruleMap.put("faultPort", FAULT_PORT);
+        ruleMap.put("count", 100);
+        ruleMap.put("duration", "1s");
+
+        HttpResponse<String> createResponse = httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/_proxy/api/rules"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(ruleMap)))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(createResponse.statusCode()).isEqualTo(201);
+        JsonNode created = mapper.readTree(createResponse.body());
+        assertThat(created.get("duration").asText()).isEqualTo("PT1S");
+
+        // Wait for expiry
+        Thread.sleep(1500);
+
+        // Request should go to upstream (rule expired), not to fault port
+        HttpResponse<String> response = httpClient.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + PROXY_PORT + "/api/hello"))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(mapper.readTree(response.body()).get("message").asText()).isEqualTo("hello");
     }
 }


### PR DESCRIPTION
- Implemented expiration handling for fault rules in FaultRuleStore.
- Added `clearAll` method to remove all fault rules.
- Introduced new API endpoints for creating rules with fault types and bulk clearing of rules.
- Added tests for fault type-only rule creation and rule expiration.
- Created a Node.js example with a mock upstream server and fault injection tests.
- Added Python examples for fault injection tests using requests and boto3.
- Introduced a mock implementation of Google Cloud Storage (GCS) for testing.
- Enhanced documentation for Rodriguez proxy and GCS mock.