### PR TITLE
fix(proxy): address security and performance issues

### DIFF
--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/ProxyConfig.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/ProxyConfig.java
@@ -120,6 +120,10 @@ public class ProxyConfig {
     /**
      * Returns the allowed CORS origin for the proxy API and SSE endpoints.
      *
+     * <p>Note: the default value is {@code "http://localhost:10220"} regardless of the configured
+     * {@code port}. If you change the port, set this value explicitly to match
+     * (e.g., {@code "http://localhost:<port>"}).
+     *
      * @return allowed origin (default "http://localhost:10220")
      */
     public String getAllowedOrigin() {

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/ProxyConfig.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/ProxyConfig.java
@@ -12,6 +12,8 @@ public class ProxyConfig {
     private int connectTimeoutMs = 5000;
     private int requestTimeoutMs = 30000;
     private String controlUrl = "http://localhost:10200";
+    private String allowedOrigin = "http://localhost:10220";
+    private long maxRequestBodyBytes = 10L * 1024 * 1024;
 
     /** Creates a new ProxyConfig with default values. */
     public ProxyConfig() {
@@ -113,5 +115,41 @@ public class ProxyConfig {
 
     public void setControlUrl(String controlUrl) {
         this.controlUrl = controlUrl;
+    }
+
+    /**
+     * Returns the allowed CORS origin for the proxy API and SSE endpoints.
+     *
+     * @return allowed origin (default "http://localhost:10220")
+     */
+    public String getAllowedOrigin() {
+        return allowedOrigin;
+    }
+
+    /**
+     * Sets the allowed CORS origin for the proxy API and SSE endpoints.
+     *
+     * @param allowedOrigin allowed origin (e.g., "http://localhost:3000")
+     */
+    public void setAllowedOrigin(String allowedOrigin) {
+        this.allowedOrigin = allowedOrigin;
+    }
+
+    /**
+     * Returns the maximum allowed request body size in bytes.
+     *
+     * @return max body size (default 10 MB)
+     */
+    public long getMaxRequestBodyBytes() {
+        return maxRequestBodyBytes;
+    }
+
+    /**
+     * Sets the maximum allowed request body size in bytes.
+     *
+     * @param maxRequestBodyBytes max body size in bytes
+     */
+    public void setMaxRequestBodyBytes(long maxRequestBodyBytes) {
+        this.maxRequestBodyBytes = maxRequestBodyBytes;
     }
 }

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/ProxyServer.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/ProxyServer.java
@@ -60,7 +60,7 @@ public class ProxyServer {
         httpServer.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
 
         httpServer.createContext("/_proxy/api/", new ApiHandler(store, config, observedPathStore));
-        httpServer.createContext("/_proxy/events", new EventStreamHandler(broadcaster));
+        httpServer.createContext("/_proxy/events", new EventStreamHandler(broadcaster, config));
         httpServer.createContext("/_proxy/ui/", new StaticFileHandler());
         httpServer.createContext("/", new ProxyHandler(httpClient, store, config, observedPathStore));
 

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/event/EventBroadcaster.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/event/EventBroadcaster.java
@@ -11,6 +11,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -22,8 +25,21 @@ import java.util.logging.Logger;
  */
 public class EventBroadcaster implements FaultRuleStore.FaultRuleListener, ObservedPathStore.Observer {
     private static final Logger LOG = Logger.getLogger(EventBroadcaster.class.getName());
+    private static final int HEARTBEAT_INTERVAL_SECONDS = 30;
     private final CopyOnWriteArrayList<OutputStream> clients = new CopyOnWriteArrayList<>();
     private final ObjectMapper mapper = new ObjectMapper();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "sse-heartbeat");
+        t.setDaemon(true);
+        return t;
+    });
+
+    /** Creates a new EventBroadcaster and starts the SSE heartbeat. */
+    public EventBroadcaster() {
+        scheduler.scheduleAtFixedRate(
+                (Runnable) this::sendHeartbeat,
+                HEARTBEAT_INTERVAL_SECONDS, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
 
     /**
      * Registers a new SSE client output stream.
@@ -32,6 +48,18 @@ public class EventBroadcaster implements FaultRuleStore.FaultRuleListener, Obser
      */
     public void addClient(OutputStream os) {
         clients.add(os);
+    }
+
+    private void sendHeartbeat() {
+        byte[] bytes = ": keep-alive\n\n".getBytes(StandardCharsets.UTF_8);
+        for (OutputStream os : clients) {
+            try {
+                os.write(bytes);
+                os.flush();
+            } catch (IOException e) {
+                clients.remove(os);
+            }
+        }
     }
 
     private void broadcast(FaultEvent event) {
@@ -97,9 +125,10 @@ public class EventBroadcaster implements FaultRuleStore.FaultRuleListener, Obser
     }
 
     /**
-     * Closes all connected SSE clients.
+     * Closes all connected SSE clients and stops the heartbeat scheduler.
      */
     public void shutdown() {
+        scheduler.shutdownNow();
         for (OutputStream os : clients) {
             try {
                 os.close();

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/event/EventBroadcaster.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/event/EventBroadcaster.java
@@ -37,7 +37,7 @@ public class EventBroadcaster implements FaultRuleStore.FaultRuleListener, Obser
     /** Creates a new EventBroadcaster and starts the SSE heartbeat. */
     public EventBroadcaster() {
         scheduler.scheduleAtFixedRate(
-                (Runnable) this::sendHeartbeat,
+                this::sendHeartbeat,
                 HEARTBEAT_INTERVAL_SECONDS, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/ApiHandler.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/ApiHandler.java
@@ -45,6 +45,8 @@ public class ApiHandler implements HttpHandler {
     private final ObservedPathStore observedPathStore;
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private final Map<String, Integer> behaviorPortCache = new ConcurrentHashMap<>();
+    private final Map<String, Long> behaviorPortCacheTime = new ConcurrentHashMap<>();
+    private static final long BEHAVIOR_CACHE_TTL_MS = 60_000L;
 
     /**
      * Creates a new API handler.
@@ -61,7 +63,7 @@ public class ApiHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", config.getAllowedOrigin());
         exchange.getResponseHeaders().set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
         exchange.getResponseHeaders().set("Access-Control-Allow-Headers", "Content-Type");
 
@@ -158,10 +160,20 @@ public class ApiHandler implements HttpHandler {
             faultPort = resolved;
         }
 
+        if (faultPort < 1 || faultPort > 65535) {
+            sendJson(exchange, 400, mapper.writeValueAsBytes(
+                    Map.of("error", "faultPort must be between 1 and 65535")));
+            return;
+        }
+
         String duration = (String) json.get("duration");
         FaultRule rule;
         try {
             rule = new FaultRule(pathPattern, faultType, faultPort, count, duration);
+        } catch (java.util.regex.PatternSyntaxException e) {
+            sendJson(exchange, 400, mapper.writeValueAsBytes(
+                    Map.of("error", "Invalid pathPattern regex: " + e.getDescription())));
+            return;
         } catch (IllegalArgumentException e) {
             sendJson(exchange, 400, mapper.writeValueAsBytes(
                     Map.of("error", "Invalid duration: " + duration + " (use e.g. \"30s\", \"5m\", \"1h\")")));
@@ -203,11 +215,11 @@ public class ApiHandler implements HttpHandler {
 
             List<BehaviorInfo> behaviors = new ArrayList<>();
             if (ports != null) {
-                ports.fields().forEachRemaining(entry -> {
+                for (var entry : ports.properties()) {
                     int port = Integer.parseInt(entry.getKey());
                     String type = entry.getValue().path("type").asText();
                     behaviors.add(new BehaviorInfo(type, port, ""));
-                });
+                }
             }
             sendJson(exchange, 200, mapper.writeValueAsBytes(behaviors));
         } catch (InterruptedException e) {
@@ -222,7 +234,9 @@ public class ApiHandler implements HttpHandler {
 
     private Integer resolveFaultPort(String faultType) {
         Integer cached = behaviorPortCache.get(faultType);
-        if (cached != null) {
+        Long cachedAt = behaviorPortCacheTime.get(faultType);
+        if (cached != null && cachedAt != null
+                && (System.currentTimeMillis() - cachedAt) < BEHAVIOR_CACHE_TTL_MS) {
             return cached;
         }
         try {
@@ -233,10 +247,12 @@ public class ApiHandler implements HttpHandler {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             JsonNode ports = mapper.readTree(response.body()).get("ports");
             if (ports != null) {
-                ports.fields().forEachRemaining(entry -> {
+                long now = System.currentTimeMillis();
+                for (var entry : ports.properties()) {
                     String type = entry.getValue().path("type").asText();
                     behaviorPortCache.put(type, Integer.parseInt(entry.getKey()));
-                });
+                    behaviorPortCacheTime.put(type, now);
+                }
             }
         } catch (IOException | InterruptedException e) {
             LOG.log(Level.WARNING, "Failed to fetch behaviors from control API", e);

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/EventStreamHandler.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/EventStreamHandler.java
@@ -2,6 +2,7 @@ package net.unit8.rodriguez.proxy.handler;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import net.unit8.rodriguez.proxy.ProxyConfig;
 import net.unit8.rodriguez.proxy.event.EventBroadcaster;
 
 import java.io.IOException;
@@ -15,14 +16,17 @@ import java.io.OutputStream;
  */
 public class EventStreamHandler implements HttpHandler {
     private final EventBroadcaster broadcaster;
+    private final ProxyConfig config;
 
     /**
      * Creates a new event stream handler.
      *
      * @param broadcaster the event broadcaster to register clients with
+     * @param config      proxy configuration (used for CORS allowed origin)
      */
-    public EventStreamHandler(EventBroadcaster broadcaster) {
+    public EventStreamHandler(EventBroadcaster broadcaster, ProxyConfig config) {
         this.broadcaster = broadcaster;
+        this.config = config;
     }
 
     @Override
@@ -30,7 +34,7 @@ public class EventStreamHandler implements HttpHandler {
         exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
         exchange.getResponseHeaders().set("Cache-Control", "no-cache");
         exchange.getResponseHeaders().set("Connection", "keep-alive");
-        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", config.getAllowedOrigin());
         exchange.sendResponseHeaders(200, 0);
 
         OutputStream os = exchange.getResponseBody();

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/ProxyHandler.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/ProxyHandler.java
@@ -82,7 +82,21 @@ public class ProxyHandler implements HttpHandler {
             String query = exchange.getRequestURI().getRawQuery();
             String targetUri = targetBase + path + (query != null ? "?" + query : "");
 
+            String contentLengthHeader = exchange.getRequestHeaders().getFirst("Content-Length");
+            if (contentLengthHeader != null) {
+                long contentLength = Long.parseLong(contentLengthHeader);
+                if (contentLength > config.getMaxRequestBodyBytes()) {
+                    exchange.sendResponseHeaders(413, -1);
+                    exchange.close();
+                    return;
+                }
+            }
             byte[] requestBody = exchange.getRequestBody().readAllBytes();
+            if (requestBody.length > config.getMaxRequestBodyBytes()) {
+                exchange.sendResponseHeaders(413, -1);
+                exchange.close();
+                return;
+            }
 
             HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(targetUri))

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/StaticFileHandler.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/StaticFileHandler.java
@@ -30,7 +30,7 @@ public class StaticFileHandler implements HttpHandler {
             }
 
             if (resourcePath.contains("..") || !resourcePath.startsWith(RESOURCE_PREFIX + "/")) {
-                exchange.sendResponseHeaders(400, -1);
+                exchange.sendResponseHeaders(403, -1);
                 return;
             }
 

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/StaticFileHandler.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/handler/StaticFileHandler.java
@@ -29,6 +29,11 @@ public class StaticFileHandler implements HttpHandler {
                 resourcePath += "index.html";
             }
 
+            if (resourcePath.contains("..") || !resourcePath.startsWith(RESOURCE_PREFIX + "/")) {
+                exchange.sendResponseHeaders(400, -1);
+                return;
+            }
+
             try (InputStream is = getClass().getResourceAsStream(resourcePath)) {
                 if (is == null) {
                     exchange.sendResponseHeaders(404, -1);

--- a/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/store/FaultRuleStore.java
+++ b/rodriguez-proxy/src/main/java/net/unit8/rodriguez/proxy/store/FaultRuleStore.java
@@ -3,7 +3,6 @@ package net.unit8.rodriguez.proxy.store;
 import net.unit8.rodriguez.proxy.model.FaultRule;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -13,8 +12,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * When a rule's remaining count reaches zero, it is automatically removed.
  */
 public class FaultRuleStore {
-    private final ConcurrentHashMap<String, FaultRule> rules = new ConcurrentHashMap<>();
-    private final CopyOnWriteArrayList<String> ruleOrder = new CopyOnWriteArrayList<>();
+    private final LinkedHashMap<String, FaultRule> orderedRules = new LinkedHashMap<>();
     private final List<FaultRuleListener> listeners = new CopyOnWriteArrayList<>();
 
     /**
@@ -59,8 +57,9 @@ public class FaultRuleStore {
      * @param rule the rule to add
      */
     public void addRule(FaultRule rule) {
-        rules.put(rule.getId(), rule);
-        ruleOrder.add(rule.getId());
+        synchronized (orderedRules) {
+            orderedRules.put(rule.getId(), rule);
+        }
         listeners.forEach(l -> l.onRuleAdded(rule));
     }
 
@@ -70,9 +69,11 @@ public class FaultRuleStore {
      * @param id the rule ID to remove
      */
     public void removeRule(String id) {
-        FaultRule removed = rules.remove(id);
+        FaultRule removed;
+        synchronized (orderedRules) {
+            removed = orderedRules.remove(id);
+        }
         if (removed != null) {
-            ruleOrder.remove(id);
             listeners.forEach(l -> l.onRuleRemoved(removed));
         }
     }
@@ -84,7 +85,10 @@ public class FaultRuleStore {
      * @return the updated rule, or empty if not found
      */
     public Optional<FaultRule> incrementRule(String id) {
-        FaultRule rule = rules.get(id);
+        FaultRule rule;
+        synchronized (orderedRules) {
+            rule = orderedRules.get(id);
+        }
         if (rule == null) return Optional.empty();
         int remaining = rule.incrementAndGet();
         listeners.forEach(l -> l.onRuleConsumed(rule, remaining));
@@ -99,21 +103,20 @@ public class FaultRuleStore {
      * @return the matched rule, or empty if no rule matches
      */
     public Optional<FaultRule> findAndConsume(String path) {
-        for (String id : ruleOrder) {
-            FaultRule rule = rules.get(id);
-            if (rule == null) continue;
+        List<FaultRule> snapshot;
+        synchronized (orderedRules) {
+            snapshot = new ArrayList<>(orderedRules.values());
+        }
+
+        for (FaultRule rule : snapshot) {
             if (rule.isExpired()) {
-                rules.remove(id);
-                ruleOrder.remove(id);
-                listeners.forEach(l -> l.onRuleRemoved(rule));
+                removeRule(rule.getId());
                 continue;
             }
             if (rule.matches(path)) {
                 int remaining = rule.decrementAndGet();
                 if (remaining <= 0) {
-                    rules.remove(id);
-                    ruleOrder.remove(id);
-                    listeners.forEach(l -> l.onRuleRemoved(rule));
+                    removeRule(rule.getId());
                 } else {
                     listeners.forEach(l -> l.onRuleConsumed(rule, remaining));
                 }
@@ -127,9 +130,11 @@ public class FaultRuleStore {
      * Removes all fault rules from the store.
      */
     public void clearAll() {
-        List<FaultRule> removed = new ArrayList<>(rules.values());
-        rules.clear();
-        ruleOrder.clear();
+        List<FaultRule> removed;
+        synchronized (orderedRules) {
+            removed = new ArrayList<>(orderedRules.values());
+            orderedRules.clear();
+        }
         removed.forEach(rule -> listeners.forEach(l -> l.onRuleRemoved(rule)));
     }
 
@@ -139,17 +144,18 @@ public class FaultRuleStore {
      * @return unmodifiable list of active rules
      */
     public List<FaultRule> listRules() {
+        List<FaultRule> snapshot;
+        synchronized (orderedRules) {
+            snapshot = new ArrayList<>(orderedRules.values());
+        }
+
         List<FaultRule> result = new ArrayList<>();
-        for (String id : ruleOrder) {
-            FaultRule rule = rules.get(id);
-            if (rule == null) continue;
+        for (FaultRule rule : snapshot) {
             if (rule.isExpired()) {
-                rules.remove(id);
-                ruleOrder.remove(id);
-                listeners.forEach(l -> l.onRuleRemoved(rule));
-                continue;
+                removeRule(rule.getId());
+            } else {
+                result.add(rule);
             }
-            result.add(rule);
         }
         return Collections.unmodifiableList(result);
     }

--- a/rodriguez-proxy/src/test/java/net/unit8/rodriguez/proxy/ProxyServerTest.java
+++ b/rodriguez-proxy/src/test/java/net/unit8/rodriguez/proxy/ProxyServerTest.java
@@ -71,6 +71,7 @@ class ProxyServerTest {
         config.setPort(PROXY_PORT);
         config.setUpstream("http://localhost:" + UPSTREAM_PORT);
         config.setControlUrl("http://localhost:" + CONTROL_PORT);
+        config.setAllowedOrigin("http://localhost:" + PROXY_PORT);
         proxyServer = new ProxyServer(config);
         proxyServer.start();
     }
@@ -250,9 +251,8 @@ class ProxyServerTest {
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
 
-        // CORS origin is now configurable; default is "http://localhost:10220" (not wildcard)
         assertThat(response.headers().firstValue("access-control-allow-origin"))
-                .hasValueSatisfying(origin -> assertThat(origin).isNotEqualTo("*"));
+                .hasValue("http://localhost:" + PROXY_PORT);
     }
 
     @Test

--- a/rodriguez-proxy/src/test/java/net/unit8/rodriguez/proxy/ProxyServerTest.java
+++ b/rodriguez-proxy/src/test/java/net/unit8/rodriguez/proxy/ProxyServerTest.java
@@ -250,8 +250,9 @@ class ProxyServerTest {
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
 
+        // CORS origin is now configurable; default is "http://localhost:10220" (not wildcard)
         assertThat(response.headers().firstValue("access-control-allow-origin"))
-                .hasValue("*");
+                .hasValueSatisfying(origin -> assertThat(origin).isNotEqualTo("*"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **CORS wildcard → configurable origin**: `Access-Control-Allow-Origin: *` を `allowedOrigin` 設定値に変更（デフォルト `http://localhost:10220`）。`ProxyConfig.setAllowedOrigin()` で上書き可能
- **パストラバーサル対策**: `StaticFileHandler` で `..` を含むパスおよび `/static/proxy/` 外のパスを 400 で拒否
- **faultPort 範囲チェック**: 1–65535 範囲外の場合 400 を返す
- **PatternSyntaxException → 400**: 無効な regex を pathPattern に指定した場合 500 ではなく 400 を返す
- **リクエストボディサイズ上限**: `maxRequestBodyBytes`（デフォルト 10MB）を超えるリクエストに 413 を返す（`ProxyConfig` で変更可能）
- **SSE ハートビート**: 30 秒ごとに `": keep-alive"` コメントを送信し、切断クライアントを早期検知
- **behaviorPortCache TTL**: 60 秒で再取得し、コントロール API の設定変更を反映
- **FaultRuleStore O(1) remove**: `CopyOnWriteArrayList + ConcurrentHashMap` → `synchronized LinkedHashMap` に置き換え、`removeRule` を O(n) → O(1) に改善

## Test plan

- [ ] `mvn test -pl rodriguez-proxy` が全 19 テストパスすることを確認
- [ ] CORS ヘッダーが `*` でなく設定値を返すことを確認
- [ ] 大きなリクエストボディ（>10MB）で 413 が返ることを確認
- [ ] 無効な regex で 400 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)